### PR TITLE
Update path to external link icon

### DIFF
--- a/install_cli.md
+++ b/install_cli.md
@@ -33,8 +33,7 @@ lastupdated: "2018-05-24"
 Use {{site.data.keyword.Bluemix_notm}} command line interface to download, modify, and redeploy your Cloud Foundry applications and service instances.
 {:shortdesc}
 
-Before you begin, download and install the {{site.data.keyword.Bluemix_notm}} [CLI](/docs/cli/index.html#overview){: new_window} ![External link icon](../../../icons/launch-glyph.svg)
-
+Before you begin, download and install the {{site.data.keyword.Bluemix_notm}} [CLI](/docs/cli/index.html#overview){: new_window} ![External link icon](../../icons/launch-glyph.svg "External link icon")
 
 **Restriction:** The command line tool is not supported by Cygwin. Use the tool in a command line window other than the Cygwin command line window.
 {:prereq}


### PR DESCRIPTION
I think you have 1 too many directories in your relative path to the icon. This change also adds the alt text.